### PR TITLE
Use config_loc to locate checkstyle suppressions

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -84,7 +84,7 @@
     <module name="SuppressWarningsFilter"/>
 
     <module name="SuppressionFilter">
-        <property name="file" value="config/checkstyle/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
 


### PR DESCRIPTION
Required to support Java 11. See https://github.com/gradle/gradle/issues/8286 for details.